### PR TITLE
调整布局，服务器在线时间可以占据剩余空间

### DIFF
--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -173,8 +173,8 @@ const Node = ({ basic, live, online }: NodeProps) => {
                     <Flag flag={basic.region} />
                   </span>
                 )}
-                <span className="hidden sm:inline opacity-40">•</span>
-                <span className="hidden sm:inline">{formatUptime(liveData.uptime, t)}</span>
+                <span className="opacity-40">•</span>
+                <span>{formatUptime(liveData.uptime, t)}</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
#### 调整前：

服务器在线时间不会占据右侧剩余空间会出现两行，整体不美观

<img width="1532" height="487" alt="before" src="https://github.com/user-attachments/assets/660aea25-ccc8-452d-8533-b0c173eda768" />

---

#### 调整后：

将服务器名和服务器状态放在一行，在线时间单独一行，不会出现换行更加美观。

<img width="1627" height="426" alt="after" src="https://github.com/user-attachments/assets/6b16fc20-9894-412e-9f21-4af35d2f9d41" />

