### PR TITLE
fix(map): highlight Turkey and small regions

### DIFF
--- a/src/components/NodeMapView.css
+++ b/src/components/NodeMapView.css
@@ -100,6 +100,60 @@
   stroke-width: 1.6;
 }
 
+.node-map-view__marker {
+  cursor: pointer;
+}
+
+.node-map-view__marker-halo,
+.node-map-view__marker-dot {
+  vector-effect: non-scaling-stroke;
+  transition:
+    opacity 180ms ease,
+    r 180ms ease,
+    stroke-width 180ms ease;
+}
+
+.node-map-view__marker-halo {
+  fill: rgba(255, 255, 255, 0.72);
+  stroke-width: 1.4;
+}
+
+.node-map-view__marker-dot {
+  stroke: rgba(255, 255, 255, 0.9);
+  stroke-width: 1.2;
+}
+
+.node-map-view__marker.status-online .node-map-view__marker-halo {
+  stroke: rgba(5, 150, 105, 0.72);
+}
+
+.node-map-view__marker.status-online .node-map-view__marker-dot {
+  fill: rgb(16, 185, 129);
+}
+
+.node-map-view__marker.status-partial .node-map-view__marker-halo {
+  stroke: rgba(217, 119, 6, 0.72);
+}
+
+.node-map-view__marker.status-partial .node-map-view__marker-dot {
+  fill: rgb(245, 158, 11);
+}
+
+.node-map-view__marker.status-offline .node-map-view__marker-halo {
+  stroke: rgba(225, 29, 72, 0.7);
+}
+
+.node-map-view__marker.status-offline .node-map-view__marker-dot {
+  fill: rgb(244, 63, 94);
+}
+
+.node-map-view__marker:hover .node-map-view__marker-halo,
+.node-map-view__marker.is-selected .node-map-view__marker-halo {
+  opacity: 0.88;
+  r: 10.5;
+  stroke-width: 2;
+}
+
 .node-map-view__legend {
   grid-area: 1 / 1;
   display: flex;

--- a/src/components/NodeMapView.tsx
+++ b/src/components/NodeMapView.tsx
@@ -38,6 +38,8 @@ const MAP_HORIZONTAL_PADDING = 28;
 const MAP_TOP_PADDING = 42;
 const MAP_BOTTOM_INSET = 42;
 const HOVER_EDGE_THRESHOLD = 380;
+const SMALL_REGION_MARKER_AREA_THRESHOLD = 14;
+const SMALL_REGION_MARKER_SIZE_THRESHOLD = 7;
 
 function getStatusText(t: TranslateFn, status: "online" | "offline" | "partial") {
   switch (status) {
@@ -111,11 +113,29 @@ export function NodeMapView({
         const name = country.properties?.name ?? String(country.id ?? "unknown");
         const pathData = pathGenerator(country as never) ?? "";
         const activeRegion = activeRegionsByMapName.get(name) ?? null;
+        const bounds = pathGenerator.bounds(country as never);
+        const width = bounds[1][0] - bounds[0][0];
+        const height = bounds[1][1] - bounds[0][1];
+        const area = pathGenerator.area(country as never);
+        const [markerX, markerY] = pathGenerator.centroid(country as never);
+        const shouldShowMarker =
+          Boolean(activeRegion) &&
+          Number.isFinite(markerX) &&
+          Number.isFinite(markerY) &&
+          (area < SMALL_REGION_MARKER_AREA_THRESHOLD ||
+            Math.max(width, height) < SMALL_REGION_MARKER_SIZE_THRESHOLD);
 
         return {
           name,
           pathData,
           activeRegion,
+          marker:
+            shouldShowMarker
+              ? {
+                  x: markerX,
+                  y: markerY,
+                }
+              : null,
         };
       })
       .filter((country) => country.pathData);
@@ -127,7 +147,7 @@ export function NodeMapView({
     };
   }, [activeRegionsByMapName]);
 
-  const getHoverPosition = useCallback((event: PointerEvent<SVGPathElement>) => {
+  const getHoverPosition = useCallback((event: PointerEvent<SVGElement>) => {
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
     const x = event.clientX;
@@ -174,7 +194,7 @@ export function NodeMapView({
   );
 
   const updateHoveredRegion = useCallback(
-    (event: PointerEvent<SVGPathElement>, region: MapRegionSummary) => {
+    (event: PointerEvent<SVGElement>, region: MapRegionSummary) => {
       const position = getHoverPosition(event);
 
       setHoveredRegion({
@@ -187,7 +207,7 @@ export function NodeMapView({
   );
 
   const updateHoverPosition = useCallback(
-    (event: PointerEvent<SVGPathElement>) => {
+    (event: PointerEvent<SVGElement>) => {
       queueHoverPosition(getHoverPosition(event));
     },
     [getHoverPosition, queueHoverPosition],
@@ -330,6 +350,54 @@ export function NodeMapView({
                     </g>
                   );
                 })}
+              </g>
+
+              <g className="node-map-view__marker-layer">
+                {projectedMap.countries
+                  .filter((country) => country.activeRegion && country.marker)
+                  .map((country) => {
+                    const region = country.activeRegion;
+                    const marker = country.marker;
+                    if (!region || !marker) {
+                      return null;
+                    }
+
+                    const isSelected = hoveredRegion?.regionKey === region.key;
+                    const ariaLabel = t("mapView.countrySummary", {
+                      name: region.label,
+                      total: region.total,
+                      online: region.online,
+                      offline: region.offline,
+                      defaultValue:
+                        "{{name}}: {{total}} nodes, {{online}} online, {{offline}} offline",
+                    });
+
+                    return (
+                      <g
+                        key={`${country.name}-marker`}
+                        className={`node-map-view__marker status-${region.status}${isSelected ? " is-selected" : ""}`}
+                        data-country-code={region.flagCode}
+                        data-country-name={country.name}
+                        aria-label={ariaLabel}
+                        onPointerEnter={(event) => updateHoveredRegion(event, region)}
+                        onPointerMove={updateHoverPosition}
+                        onPointerLeave={clearHoveredRegion}
+                      >
+                        <circle
+                          cx={marker.x}
+                          cy={marker.y}
+                          r="9"
+                          className="node-map-view__marker-halo"
+                        />
+                        <circle
+                          cx={marker.x}
+                          cy={marker.y}
+                          r="4.2"
+                          className="node-map-view__marker-dot"
+                        />
+                      </g>
+                    );
+                  })}
               </g>
             </svg>
 

--- a/src/utils/mapRegions.ts
+++ b/src/utils/mapRegions.ts
@@ -17,6 +17,7 @@ const regionMetaOverridesByFlagCode: Record<
   Partial<Pick<RegionMeta, "label" | "mapName">>
 > = {
   US: { label: "United States", mapName: "United States of America" },
+  TR: { label: "Turkey", mapName: "Turkey" },
   MO: { label: "Macau", mapName: "Macao" },
   HK: { label: "Hong Kong", mapName: "Hong Kong" },
 };


### PR DESCRIPTION
## Summary

This fixes two map highlighting issues in the dashboard:

- Maps `TR` to the TopoJSON country name `Turkey`, avoiding mismatches when `Intl.DisplayNames` resolves the region as `Türkiye`.
- Adds visible markers for active regions whose projected map shape is too small to notice, such as Singapore.

## Why

The region overview can count countries correctly, but the world map may not visibly highlight every active region. In particular:

- Turkey may fail to match the map data because the runtime display name can be `Türkiye`, while the bundled TopoJSON data uses `Turkey`.
- Singapore is matched, but its projected shape is extremely small on the map and is hard to see.

## Verification

- `npx tsc --noEmit`
- `npx eslint src/components/NodeMapView.tsx src/utils/mapRegions.ts`
- `npm run build`