### PR TITLE
Refresh ping records periodically

### DIFF
--- a/src/components/instance/PingChart.tsx
+++ b/src/components/instance/PingChart.tsx
@@ -135,8 +135,9 @@ const PingChart = ({ uuid }: { uuid: string }) => {
     }
     setLoading(true);
     setError(null);
-    const controller = new AbortController();
-    (async () => {
+    let cancelled = false;
+
+    const fetchRecords = async () => {
       try {
         type RpcResp = {
           count: number;
@@ -153,16 +154,27 @@ const PingChart = ({ uuid }: { uuid: string }) => {
         records.sort(
           (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime()
         );
+        if (cancelled) return;
         setRemoteData(records);
         setTasks(result?.tasks || []);
+        setError(null);
         setLoading(false);
       } catch (err: any) {
-        setError(err?.message || "Error");
-        setLoading(false);
+        if (!cancelled) {
+          setError(err?.message || "Error");
+          setLoading(false);
+        }
       }
-    })();
-    return () => controller.abort();
-  }, [hours, uuid]);
+    };
+
+    void fetchRecords();
+    const interval = window.setInterval(fetchRecords, 2000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [hours, uuid, call]);
 
   const midData = useMemo(() => {
     const data = remoteData || [];

--- a/src/hooks/usePingStats.tsx
+++ b/src/hooks/usePingStats.tsx
@@ -98,9 +98,9 @@ export function usePingStats(uuid: string, hours: number = 24): PingStats {
   useEffect(() => {
     if (!uuid) return;
 
-    const controller = new AbortController();
+    let cancelled = false;
 
-    (async () => {
+    const fetchStats = async () => {
       try {
         type RpcResp = {
           count: number;
@@ -118,6 +118,8 @@ export function usePingStats(uuid: string, hours: number = 24): PingStats {
 
         const records = result?.records || [];
         const tasks = result?.tasks || [];
+
+        if (cancelled) return;
 
         if (records.length === 0 || tasks.length === 0) {
           setStats(createEmptyStats());
@@ -153,11 +155,19 @@ export function usePingStats(uuid: string, hours: number = 24): PingStats {
           hasData: true,
         });
       } catch (err) {
-        setStats(createEmptyStats());
+        if (!cancelled) {
+          setStats(createEmptyStats());
+        }
       }
-    })();
+    };
 
-    return () => controller.abort();
+    void fetchStats();
+    const interval = window.setInterval(fetchStats, 2000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
   }, [uuid, hours, call]);
 
   return stats;


### PR DESCRIPTION
## Summary
- Refresh homepage ping statistics every 2 seconds after the initial load.
- Refresh the instance ping chart every 2 seconds while the panel is mounted.
- Clear intervals on unmount to avoid updating stale components.

## Why
Ping statistics and history were only fetched once when the component mounted, so the UI could stay stale while the rest of the dashboard kept updating.

## Validation
- `npx tsc --noEmit`
