### PR TITLE
Add bg Mask Opacity

### DIFF
--- a/komari-theme.json
+++ b/komari-theme.json
@@ -1,1099 +1,1157 @@
 {
-  "name": "Komari Next",
-  "short": "next",
-  "description": "NextJS theme for Komari Monitor",
-  "version": "1.4.9",
-  "author": "tonyliuzj",
-  "url": "https://github.com/tonyliuzj/komari-next",
-  "preview": "preview.png",
-  "configuration": {
-    "name": "Theme Settings",
-    "icon": "Palette",
-    "description": "Komari Next theme defaults",
-    "managedFields": [
-      {
-        "key": "colorTheme",
-        "type": "option",
-        "label": "Default color theme",
-        "options": [
-          "default",
-          "ocean",
-          "sunset",
-          "forest",
-          "midnight",
-          "rose"
+    "name": "Komari Next",
+    "short": "next",
+    "description": "NextJS theme for Komari Monitor",
+    "version": "1.4.9",
+    "author": "tonyliuzj",
+    "url": "https://github.com/tonyliuzj/komari-next",
+    "preview": "preview.png",
+    "configuration": {
+        "name": "Theme Settings",
+        "icon": "Palette",
+        "description": "Komari Next theme defaults",
+        "managedFields": [
+            {
+                "key": "colorTheme",
+                "type": "option",
+                "label": "Default color theme",
+                "options": [
+                    "default",
+                    "ocean",
+                    "sunset",
+                    "forest",
+                    "midnight",
+                    "rose"
+                ],
+                "default": "default"
+            },
+            {
+                "key": "cardLayout",
+                "type": "option",
+                "label": "Default card layout",
+                "options": [
+                    "classic",
+                    "modern",
+                    "minimal",
+                    "detailed"
+                ],
+                "default": "classic"
+            },
+            {
+                "key": "cardDesign",
+                "type": "option",
+                "label": "Default card design",
+                "options": [
+                    "default",
+                    "quality-bars"
+                ],
+                "default": "default"
+            },
+            {
+                "key": "cardBlurEnabled",
+                "type": "bool",
+                "label": "Enable card background blur",
+                "default": false
+            },
+            {
+                "key": "cardBlurType",
+                "type": "option",
+                "label": "Card background blur type",
+                "options": [
+                    "soft",
+                    "glass"
+                ],
+                "default": "glass"
+            },
+            {
+                "key": "cardBlurIntensity",
+                "type": "number",
+                "label": "Card background transparent intensity",
+                "default": 35
+            },
+            {
+                "key": "cardExtraBlurIntensity",
+                "type": "number",
+                "label": "Card background extra blur intensity",
+                "default": 35
+            },
+            {
+                "key": "statusDesign",
+                "type": "option",
+                "label": "Default status design",
+                "options": [
+                    "default",
+                    "speed"
+                ],
+                "default": "default"
+            },
+            {
+                "key": "graphDesign",
+                "type": "option",
+                "label": "Default graph design",
+                "options": [
+                    "circle",
+                    "progress",
+                    "bar",
+                    "minimal"
+                ],
+                "default": "circle"
+            },
+            {
+                "key": "nodeViewMode",
+                "type": "option",
+                "label": "Default node view",
+                "options": [
+                    "grid",
+                    "table"
+                ],
+                "default": "grid"
+            },
+            {
+                "key": "appearance",
+                "type": "option",
+                "label": "Default appearance",
+                "options": [
+                    "light",
+                    "dark",
+                    "system"
+                ],
+                "default": "system"
+            },
+            {
+                "key": "language",
+                "type": "option",
+                "label": "Default language",
+                "options": [
+                    "auto",
+                    "en",
+                    "zh-CN",
+                    "zh-TW"
+                ],
+                "default": "auto"
+            },
+            {
+                "key": "backgroundImageUrl",
+                "type": "text",
+                "label": "Background image URL",
+                "default": ""
+            },
+            {
+                "key": "backgroundBlurEnabled",
+                "type": "bool",
+                "label": "Enable background blur",
+                "default": false
+            },
+            {
+                "key": "backgroundBlurType",
+                "type": "option",
+                "label": "Background blur type",
+                "options": [
+                    "soft",
+                    "glass"
+                ],
+                "default": "soft"
+            },
+            {
+                "key": "backgroundBlurIntensity",
+                "type": "number",
+                "label": "Background blur intensity",
+                "default": 35
+            },
+            {
+                "key": "backgroundMaskOpacity",
+                "type": "number",
+                "label": "Background mask opacity",
+                "default": 0
+            },
+            {
+                "key": "statusCardsVisibility.currentTime",
+                "type": "bool",
+                "label": "Show current time",
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.currentOnline",
+                "type": "bool",
+                "label": "Show current online",
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.regionOverview",
+                "type": "bool",
+                "label": "Show region overview",
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.trafficOverview",
+                "type": "bool",
+                "label": "Show traffic overview",
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.networkSpeed",
+                "type": "bool",
+                "label": "Show network speed",
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.mapView",
+                "type": "bool",
+                "label": "Show map view",
+                "default": true
+            }
         ],
-        "default": "default"
-      },
-      {
-        "key": "cardLayout",
-        "type": "option",
-        "label": "Default card layout",
-        "options": [
-          "classic",
-          "modern",
-          "minimal",
-          "detailed"
+        "fields": [
+            {
+                "type": "title",
+                "name": "Theme Settings"
+            },
+            {
+                "key": "colorTheme",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认颜色主题",
+                    "en-US": "Default Color Theme"
+                },
+                "help": {
+                    "zh-CN": "设置主题默认颜色方案，访客仍可在本地覆盖。",
+                    "en-US": "Set the default color scheme. Visitors can still override it locally."
+                },
+                "default": "default",
+                "options": "default,ocean,sunset,forest,midnight,rose"
+            },
+            {
+                "key": "cardLayout",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认卡片布局",
+                    "en-US": "Default Card Layout"
+                },
+                "default": "classic",
+                "options": "classic,modern,minimal,detailed"
+            },
+            {
+                "key": "cardDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认卡片设计",
+                    "en-US": "Default Card Design"
+                },
+                "default": "default",
+                "options": "default,quality-bars"
+            },
+            {
+                "key": "cardBlurEnabled",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "启用卡片背景模糊",
+                    "en-US": "Enable Card Background Blur"
+                },
+                "default": false
+            },
+            {
+                "key": "cardBlurType",
+                "type": "select",
+                "name": {
+                    "zh-CN": "卡片背景模糊类型",
+                    "en-US": "Card Background Blur Type"
+                },
+                "default": "glass",
+                "options": "soft,glass"
+            },
+            {
+                "key": "cardBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "卡片背景透明强度",
+                    "en-US": "Card Background Transparent Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "cardExtraBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "卡片背景额外模糊强度",
+                    "en-US": "Card Background Extra Blur Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "statusDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认状态设计",
+                    "en-US": "Default Status Design"
+                },
+                "default": "default",
+                "options": "default,speed"
+            },
+            {
+                "key": "graphDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认图表设计",
+                    "en-US": "Default Graph Design"
+                },
+                "default": "circle",
+                "options": "circle,progress,bar,minimal"
+            },
+            {
+                "key": "nodeViewMode",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认节点视图",
+                    "en-US": "Default Node View"
+                },
+                "default": "grid",
+                "options": "grid,table"
+            },
+            {
+                "key": "appearance",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认外观",
+                    "en-US": "Default Appearance"
+                },
+                "default": "system",
+                "options": "light,dark,system"
+            },
+            {
+                "key": "language",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认语言",
+                    "en-US": "Default Language"
+                },
+                "help": {
+                    "zh-CN": "选择 auto 时使用访客浏览器语言。",
+                    "en-US": "Use auto to follow the visitor browser language."
+                },
+                "default": "auto",
+                "options": "auto,en,zh-CN,zh-TW"
+            },
+            {
+                "key": "backgroundImageUrl",
+                "type": "string",
+                "name": {
+                    "zh-CN": "背景图片链接",
+                    "en-US": "Background Image URL"
+                },
+                "default": ""
+            },
+            {
+                "key": "backgroundBlurEnabled",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "启用背景模糊",
+                    "en-US": "Enable Background Blur"
+                },
+                "default": false
+            },
+            {
+                "key": "backgroundBlurType",
+                "type": "select",
+                "name": {
+                    "zh-CN": "背景模糊类型",
+                    "en-US": "Background Blur Type"
+                },
+                "default": "soft",
+                "options": "soft,glass"
+            },
+            {
+                "key": "backgroundBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "背景模糊强度",
+                    "en-US": "Background Blur Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "backgroundMaskOpacity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "背景蒙版不透明度",
+                    "en-US": "Background Mask Opacity"
+                },
+                "help": {
+                    "zh-CN": "在背景图片上叠加白色（浅色模式）或黑色（深色模式）蒙版，数值越大文字越易读。0 为不叠加，100 为完全覆盖。",
+                    "en-US": "Overlays a white (light mode) or black (dark mode) mask on the background image. Higher values improve text readability. 0 = no mask, 100 = fully covered."
+                },
+                "default": 0
+            },
+            {
+                "type": "title",
+                "name": "Status Cards"
+            },
+            {
+                "key": "statusCardsVisibility.currentTime",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示当前时间",
+                    "en-US": "Show Current Time"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.currentOnline",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示当前在线",
+                    "en-US": "Show Current Online"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.regionOverview",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示点亮地区",
+                    "en-US": "Show Region Overview"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.trafficOverview",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示流量概览",
+                    "en-US": "Show Traffic Overview"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.networkSpeed",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示网络速率",
+                    "en-US": "Show Network Speed"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.mapView",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示地图",
+                    "en-US": "Show Map View"
+                },
+                "default": true
+            }
         ],
-        "default": "classic"
-      },
-      {
-        "key": "cardDesign",
-        "type": "option",
-        "label": "Default card design",
         "options": [
-          "default",
-          "quality-bars"
+            {
+                "type": "title",
+                "name": "Theme Settings"
+            },
+            {
+                "key": "colorTheme",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认颜色主题",
+                    "en-US": "Default Color Theme"
+                },
+                "default": "default",
+                "options": "default,ocean,sunset,forest,midnight,rose"
+            },
+            {
+                "key": "cardLayout",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认卡片布局",
+                    "en-US": "Default Card Layout"
+                },
+                "default": "classic",
+                "options": "classic,modern,minimal,detailed"
+            },
+            {
+                "key": "cardDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认卡片设计",
+                    "en-US": "Default Card Design"
+                },
+                "default": "default",
+                "options": "default,quality-bars"
+            },
+            {
+                "key": "cardBlurEnabled",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "启用卡片背景模糊",
+                    "en-US": "Enable Card Background Blur"
+                },
+                "default": false
+            },
+            {
+                "key": "cardBlurType",
+                "type": "select",
+                "name": {
+                    "zh-CN": "卡片背景模糊类型",
+                    "en-US": "Card Background Blur Type"
+                },
+                "default": "glass",
+                "options": "soft,glass"
+            },
+            {
+                "key": "cardBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "卡片背景透明强度",
+                    "en-US": "Card Background Transparent Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "cardExtraBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "卡片背景额外模糊强度",
+                    "en-US": "Card Background Extra Blur Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "statusDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认状态设计",
+                    "en-US": "Default Status Design"
+                },
+                "default": "default",
+                "options": "default,speed"
+            },
+            {
+                "key": "graphDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认图表设计",
+                    "en-US": "Default Graph Design"
+                },
+                "default": "circle",
+                "options": "circle,progress,bar,minimal"
+            },
+            {
+                "key": "nodeViewMode",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认节点视图",
+                    "en-US": "Default Node View"
+                },
+                "default": "grid",
+                "options": "grid,table"
+            },
+            {
+                "key": "appearance",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认外观",
+                    "en-US": "Default Appearance"
+                },
+                "default": "system",
+                "options": "light,dark,system"
+            },
+            {
+                "key": "language",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认语言",
+                    "en-US": "Default Language"
+                },
+                "help": {
+                    "zh-CN": "选择 auto 时使用访客浏览器语言。",
+                    "en-US": "Use auto to follow the visitor browser language."
+                },
+                "default": "auto",
+                "options": "auto,en,zh-CN,zh-TW"
+            },
+            {
+                "key": "backgroundImageUrl",
+                "type": "string",
+                "name": {
+                    "zh-CN": "背景图片链接",
+                    "en-US": "Background Image URL"
+                },
+                "default": ""
+            },
+            {
+                "key": "backgroundBlurEnabled",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "启用背景模糊",
+                    "en-US": "Enable Background Blur"
+                },
+                "default": false
+            },
+            {
+                "key": "backgroundBlurType",
+                "type": "select",
+                "name": {
+                    "zh-CN": "背景模糊类型",
+                    "en-US": "Background Blur Type"
+                },
+                "default": "soft",
+                "options": "soft,glass"
+            },
+            {
+                "key": "backgroundBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "背景模糊强度",
+                    "en-US": "Background Blur Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "backgroundMaskOpacity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "背景蒙版不透明度",
+                    "en-US": "Background Mask Opacity"
+                },
+                "help": {
+                    "zh-CN": "在背景图片上叠加白色（浅色模式）或黑色（深色模式）蒙版，数值越大文字越易读。0 为不叠加，100 为完全覆盖。",
+                    "en-US": "Overlays a white (light mode) or black (dark mode) mask on the background image. Higher values improve text readability. 0 = no mask, 100 = fully covered."
+                },
+                "default": 0
+            },
+            {
+                "type": "title",
+                "name": "Status Cards"
+            },
+            {
+                "key": "statusCardsVisibility.currentTime",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示当前时间",
+                    "en-US": "Show Current Time"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.currentOnline",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示当前在线",
+                    "en-US": "Show Current Online"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.regionOverview",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示点亮地区",
+                    "en-US": "Show Region Overview"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.trafficOverview",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示流量概览",
+                    "en-US": "Show Traffic Overview"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.networkSpeed",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示网络速率",
+                    "en-US": "Show Network Speed"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.mapView",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示地图",
+                    "en-US": "Show Map View"
+                },
+                "default": true
+            }
         ],
-        "default": "default"
-      },
-      {
-        "key": "cardBlurEnabled",
-        "type": "bool",
-        "label": "Enable card background blur",
-        "default": false
-      },
-      {
-        "key": "cardBlurType",
-        "type": "option",
-        "label": "Card background blur type",
-        "options": [
-          "soft",
-          "glass"
+        "items": [
+            {
+                "type": "title",
+                "name": "Theme Settings"
+            },
+            {
+                "key": "colorTheme",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认颜色主题",
+                    "en-US": "Default Color Theme"
+                },
+                "help": {
+                    "zh-CN": "设置主题默认颜色方案，访客仍可在本地覆盖。",
+                    "en-US": "Set the default color scheme. Visitors can still override it locally."
+                },
+                "default": "default",
+                "options": "default,ocean,sunset,forest,midnight,rose"
+            },
+            {
+                "key": "cardLayout",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认卡片布局",
+                    "en-US": "Default Card Layout"
+                },
+                "default": "classic",
+                "options": "classic,modern,minimal,detailed"
+            },
+            {
+                "key": "cardDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认卡片设计",
+                    "en-US": "Default Card Design"
+                },
+                "default": "default",
+                "options": "default,quality-bars"
+            },
+            {
+                "key": "cardBlurEnabled",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "启用卡片背景模糊",
+                    "en-US": "Enable Card Background Blur"
+                },
+                "default": false
+            },
+            {
+                "key": "cardBlurType",
+                "type": "select",
+                "name": {
+                    "zh-CN": "卡片背景模糊类型",
+                    "en-US": "Card Background Blur Type"
+                },
+                "default": "glass",
+                "options": "soft,glass"
+            },
+            {
+                "key": "cardBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "卡片背景透明强度",
+                    "en-US": "Card Background Transparent Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "cardExtraBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "卡片背景额外模糊强度",
+                    "en-US": "Card Background Extra Blur Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "statusDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认状态设计",
+                    "en-US": "Default Status Design"
+                },
+                "default": "default",
+                "options": "default,speed"
+            },
+            {
+                "key": "graphDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认图表设计",
+                    "en-US": "Default Graph Design"
+                },
+                "default": "circle",
+                "options": "circle,progress,bar,minimal"
+            },
+            {
+                "key": "nodeViewMode",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认节点视图",
+                    "en-US": "Default Node View"
+                },
+                "default": "grid",
+                "options": "grid,table"
+            },
+            {
+                "key": "appearance",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认外观",
+                    "en-US": "Default Appearance"
+                },
+                "default": "system",
+                "options": "light,dark,system"
+            },
+            {
+                "key": "language",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认语言",
+                    "en-US": "Default Language"
+                },
+                "help": {
+                    "zh-CN": "选择 auto 时使用访客浏览器语言。",
+                    "en-US": "Use auto to follow the visitor browser language."
+                },
+                "default": "auto",
+                "options": "auto,en,zh-CN,zh-TW"
+            },
+            {
+                "key": "backgroundImageUrl",
+                "type": "string",
+                "name": {
+                    "zh-CN": "背景图片链接",
+                    "en-US": "Background Image URL"
+                },
+                "default": ""
+            },
+            {
+                "key": "backgroundBlurEnabled",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "启用背景模糊",
+                    "en-US": "Enable Background Blur"
+                },
+                "default": false
+            },
+            {
+                "key": "backgroundBlurType",
+                "type": "select",
+                "name": {
+                    "zh-CN": "背景模糊类型",
+                    "en-US": "Background Blur Type"
+                },
+                "default": "soft",
+                "options": "soft,glass"
+            },
+            {
+                "key": "backgroundBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "背景模糊强度",
+                    "en-US": "Background Blur Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "backgroundMaskOpacity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "背景蒙版不透明度",
+                    "en-US": "Background Mask Opacity"
+                },
+                "help": {
+                    "zh-CN": "在背景图片上叠加白色（浅色模式）或黑色（深色模式）蒙版，数值越大文字越易读。0 为不叠加，100 为完全覆盖。",
+                    "en-US": "Overlays a white (light mode) or black (dark mode) mask on the background image. Higher values improve text readability. 0 = no mask, 100 = fully covered."
+                },
+                "default": 0
+            },
+            {
+                "type": "title",
+                "name": "Status Cards"
+            },
+            {
+                "key": "statusCardsVisibility.currentTime",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示当前时间",
+                    "en-US": "Show Current Time"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.currentOnline",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示当前在线",
+                    "en-US": "Show Current Online"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.regionOverview",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示点亮地区",
+                    "en-US": "Show Region Overview"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.trafficOverview",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示流量概览",
+                    "en-US": "Show Traffic Overview"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.networkSpeed",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示网络速率",
+                    "en-US": "Show Network Speed"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.mapView",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示地图",
+                    "en-US": "Show Map View"
+                },
+                "default": true
+            }
         ],
-        "default": "glass"
-      },
-      {
-        "key": "cardBlurIntensity",
-        "type": "number",
-        "label": "Card background transparent intensity",
-        "default": 35
-      },
-      {
-        "key": "cardExtraBlurIntensity",
-        "type": "number",
-        "label": "Card background extra blur intensity",
-        "default": 35
-      },
-      {
-        "key": "statusDesign",
-        "type": "option",
-        "label": "Default status design",
-        "options": [
-          "default",
-          "speed"
-        ],
-        "default": "default"
-      },
-      {
-        "key": "graphDesign",
-        "type": "option",
-        "label": "Default graph design",
-        "options": [
-          "circle",
-          "progress",
-          "bar",
-          "minimal"
-        ],
-        "default": "circle"
-      },
-      {
-        "key": "nodeViewMode",
-        "type": "option",
-        "label": "Default node view",
-        "options": [
-          "grid",
-          "table"
-        ],
-        "default": "grid"
-      },
-      {
-        "key": "appearance",
-        "type": "option",
-        "label": "Default appearance",
-        "options": [
-          "light",
-          "dark",
-          "system"
-        ],
-        "default": "system"
-      },
-      {
-        "key": "language",
-        "type": "option",
-        "label": "Default language",
-        "options": [
-          "auto",
-          "en",
-          "zh-CN",
-          "zh-TW"
-        ],
-        "default": "auto"
-      },
-      {
-        "key": "backgroundImageUrl",
-        "type": "text",
-        "label": "Background image URL",
-        "default": ""
-      },
-      {
-        "key": "backgroundBlurEnabled",
-        "type": "bool",
-        "label": "Enable background blur",
-        "default": false
-      },
-      {
-        "key": "backgroundBlurType",
-        "type": "option",
-        "label": "Background blur type",
-        "options": [
-          "soft",
-          "glass"
-        ],
-        "default": "soft"
-      },
-      {
-        "key": "backgroundBlurIntensity",
-        "type": "number",
-        "label": "Background blur intensity",
-        "default": 35
-      },
-      {
-        "key": "statusCardsVisibility.currentTime",
-        "type": "bool",
-        "label": "Show current time",
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.currentOnline",
-        "type": "bool",
-        "label": "Show current online",
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.regionOverview",
-        "type": "bool",
-        "label": "Show region overview",
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.trafficOverview",
-        "type": "bool",
-        "label": "Show traffic overview",
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.networkSpeed",
-        "type": "bool",
-        "label": "Show network speed",
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.mapView",
-        "type": "bool",
-        "label": "Show map view",
-        "default": true
-      }
-    ],
-    "fields": [
-      {
-        "type": "title",
-        "name": "Theme Settings"
-      },
-      {
-        "key": "colorTheme",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认颜色主题",
-          "en-US": "Default Color Theme"
-        },
-        "help": {
-          "zh-CN": "设置主题默认颜色方案，访客仍可在本地覆盖。",
-          "en-US": "Set the default color scheme. Visitors can still override it locally."
-        },
-        "default": "default",
-        "options": "default,ocean,sunset,forest,midnight,rose"
-      },
-      {
-        "key": "cardLayout",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认卡片布局",
-          "en-US": "Default Card Layout"
-        },
-        "default": "classic",
-        "options": "classic,modern,minimal,detailed"
-      },
-      {
-        "key": "cardDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认卡片设计",
-          "en-US": "Default Card Design"
-        },
-        "default": "default",
-        "options": "default,quality-bars"
-      },
-      {
-        "key": "cardBlurEnabled",
-        "type": "switch",
-        "name": {
-          "zh-CN": "启用卡片背景模糊",
-          "en-US": "Enable Card Background Blur"
-        },
-        "default": false
-      },
-      {
-        "key": "cardBlurType",
-        "type": "select",
-        "name": {
-          "zh-CN": "卡片背景模糊类型",
-          "en-US": "Card Background Blur Type"
-        },
-        "default": "glass",
-        "options": "soft,glass"
-      },
-      {
-        "key": "cardBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "卡片背景透明强度",
-          "en-US": "Card Background Transparent Intensity"
-        },
-        "default": 35
-      },
-      {
-        "key": "cardExtraBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "卡片背景额外模糊强度",
-          "en-US": "Card Background Extra Blur Intensity"
-        },
-        "default": 35
-      },
-      {
-        "key": "statusDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认状态设计",
-          "en-US": "Default Status Design"
-        },
-        "default": "default",
-        "options": "default,speed"
-      },
-      {
-        "key": "graphDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认图表设计",
-          "en-US": "Default Graph Design"
-        },
-        "default": "circle",
-        "options": "circle,progress,bar,minimal"
-      },
-      {
-        "key": "nodeViewMode",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认节点视图",
-          "en-US": "Default Node View"
-        },
-        "default": "grid",
-        "options": "grid,table"
-      },
-      {
-        "key": "appearance",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认外观",
-          "en-US": "Default Appearance"
-        },
-        "default": "system",
-        "options": "light,dark,system"
-      },
-      {
-        "key": "language",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认语言",
-          "en-US": "Default Language"
-        },
-        "help": {
-          "zh-CN": "选择 auto 时使用访客浏览器语言。",
-          "en-US": "Use auto to follow the visitor browser language."
-        },
-        "default": "auto",
-        "options": "auto,en,zh-CN,zh-TW"
-      },
-      {
-        "key": "backgroundImageUrl",
-        "type": "string",
-        "name": {
-          "zh-CN": "背景图片链接",
-          "en-US": "Background Image URL"
-        },
-        "default": ""
-      },
-      {
-        "key": "backgroundBlurEnabled",
-        "type": "switch",
-        "name": {
-          "zh-CN": "启用背景模糊",
-          "en-US": "Enable Background Blur"
-        },
-        "default": false
-      },
-      {
-        "key": "backgroundBlurType",
-        "type": "select",
-        "name": {
-          "zh-CN": "背景模糊类型",
-          "en-US": "Background Blur Type"
-        },
-        "default": "soft",
-        "options": "soft,glass"
-      },
-      {
-        "key": "backgroundBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "背景模糊强度",
-          "en-US": "Background Blur Intensity"
-        },
-        "default": 35
-      },
-      {
-        "type": "title",
-        "name": "Status Cards"
-      },
-      {
-        "key": "statusCardsVisibility.currentTime",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示当前时间",
-          "en-US": "Show Current Time"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.currentOnline",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示当前在线",
-          "en-US": "Show Current Online"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.regionOverview",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示点亮地区",
-          "en-US": "Show Region Overview"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.trafficOverview",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示流量概览",
-          "en-US": "Show Traffic Overview"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.networkSpeed",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示网络速率",
-          "en-US": "Show Network Speed"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.mapView",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示地图",
-          "en-US": "Show Map View"
-        },
-        "default": true
-      }
-    ],
-    "options": [
-      {
-        "type": "title",
-        "name": "Theme Settings"
-      },
-      {
-        "key": "colorTheme",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认颜色主题",
-          "en-US": "Default Color Theme"
-        },
-        "default": "default",
-        "options": "default,ocean,sunset,forest,midnight,rose"
-      },
-      {
-        "key": "cardLayout",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认卡片布局",
-          "en-US": "Default Card Layout"
-        },
-        "default": "classic",
-        "options": "classic,modern,minimal,detailed"
-      },
-      {
-        "key": "cardDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认卡片设计",
-          "en-US": "Default Card Design"
-        },
-        "default": "default",
-        "options": "default,quality-bars"
-      },
-      {
-        "key": "cardBlurEnabled",
-        "type": "switch",
-        "name": {
-          "zh-CN": "启用卡片背景模糊",
-          "en-US": "Enable Card Background Blur"
-        },
-        "default": false
-      },
-      {
-        "key": "cardBlurType",
-        "type": "select",
-        "name": {
-          "zh-CN": "卡片背景模糊类型",
-          "en-US": "Card Background Blur Type"
-        },
-        "default": "glass",
-        "options": "soft,glass"
-      },
-      {
-        "key": "cardBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "卡片背景透明强度",
-          "en-US": "Card Background Transparent Intensity"
-        },
-        "default": 35
-      },
-      {
-        "key": "cardExtraBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "卡片背景额外模糊强度",
-          "en-US": "Card Background Extra Blur Intensity"
-        },
-        "default": 35
-      },
-      {
-        "key": "statusDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认状态设计",
-          "en-US": "Default Status Design"
-        },
-        "default": "default",
-        "options": "default,speed"
-      },
-      {
-        "key": "graphDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认图表设计",
-          "en-US": "Default Graph Design"
-        },
-        "default": "circle",
-        "options": "circle,progress,bar,minimal"
-      },
-      {
-        "key": "nodeViewMode",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认节点视图",
-          "en-US": "Default Node View"
-        },
-        "default": "grid",
-        "options": "grid,table"
-      },
-      {
-        "key": "appearance",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认外观",
-          "en-US": "Default Appearance"
-        },
-        "default": "system",
-        "options": "light,dark,system"
-      },
-      {
-        "key": "language",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认语言",
-          "en-US": "Default Language"
-        },
-        "help": {
-          "zh-CN": "选择 auto 时使用访客浏览器语言。",
-          "en-US": "Use auto to follow the visitor browser language."
-        },
-        "default": "auto",
-        "options": "auto,en,zh-CN,zh-TW"
-      },
-      {
-        "key": "backgroundImageUrl",
-        "type": "string",
-        "name": {
-          "zh-CN": "背景图片链接",
-          "en-US": "Background Image URL"
-        },
-        "default": ""
-      },
-      {
-        "key": "backgroundBlurEnabled",
-        "type": "switch",
-        "name": {
-          "zh-CN": "启用背景模糊",
-          "en-US": "Enable Background Blur"
-        },
-        "default": false
-      },
-      {
-        "key": "backgroundBlurType",
-        "type": "select",
-        "name": {
-          "zh-CN": "背景模糊类型",
-          "en-US": "Background Blur Type"
-        },
-        "default": "soft",
-        "options": "soft,glass"
-      },
-      {
-        "key": "backgroundBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "背景模糊强度",
-          "en-US": "Background Blur Intensity"
-        },
-        "default": 35
-      },
-      {
-        "type": "title",
-        "name": "Status Cards"
-      },
-      {
-        "key": "statusCardsVisibility.currentTime",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示当前时间",
-          "en-US": "Show Current Time"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.currentOnline",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示当前在线",
-          "en-US": "Show Current Online"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.regionOverview",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示点亮地区",
-          "en-US": "Show Region Overview"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.trafficOverview",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示流量概览",
-          "en-US": "Show Traffic Overview"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.networkSpeed",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示网络速率",
-          "en-US": "Show Network Speed"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.mapView",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示地图",
-          "en-US": "Show Map View"
-        },
-        "default": true
-      }
-    ],
-    "items": [
-      {
-        "type": "title",
-        "name": "Theme Settings"
-      },
-      {
-        "key": "colorTheme",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认颜色主题",
-          "en-US": "Default Color Theme"
-        },
-        "help": {
-          "zh-CN": "设置主题默认颜色方案，访客仍可在本地覆盖。",
-          "en-US": "Set the default color scheme. Visitors can still override it locally."
-        },
-        "default": "default",
-        "options": "default,ocean,sunset,forest,midnight,rose"
-      },
-      {
-        "key": "cardLayout",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认卡片布局",
-          "en-US": "Default Card Layout"
-        },
-        "default": "classic",
-        "options": "classic,modern,minimal,detailed"
-      },
-      {
-        "key": "cardDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认卡片设计",
-          "en-US": "Default Card Design"
-        },
-        "default": "default",
-        "options": "default,quality-bars"
-      },
-      {
-        "key": "cardBlurEnabled",
-        "type": "switch",
-        "name": {
-          "zh-CN": "启用卡片背景模糊",
-          "en-US": "Enable Card Background Blur"
-        },
-        "default": false
-      },
-      {
-        "key": "cardBlurType",
-        "type": "select",
-        "name": {
-          "zh-CN": "卡片背景模糊类型",
-          "en-US": "Card Background Blur Type"
-        },
-        "default": "glass",
-        "options": "soft,glass"
-      },
-      {
-        "key": "cardBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "卡片背景透明强度",
-          "en-US": "Card Background Transparent Intensity"
-        },
-        "default": 35
-      },
-      {
-        "key": "cardExtraBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "卡片背景额外模糊强度",
-          "en-US": "Card Background Extra Blur Intensity"
-        },
-        "default": 35
-      },
-      {
-        "key": "statusDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认状态设计",
-          "en-US": "Default Status Design"
-        },
-        "default": "default",
-        "options": "default,speed"
-      },
-      {
-        "key": "graphDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认图表设计",
-          "en-US": "Default Graph Design"
-        },
-        "default": "circle",
-        "options": "circle,progress,bar,minimal"
-      },
-      {
-        "key": "nodeViewMode",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认节点视图",
-          "en-US": "Default Node View"
-        },
-        "default": "grid",
-        "options": "grid,table"
-      },
-      {
-        "key": "appearance",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认外观",
-          "en-US": "Default Appearance"
-        },
-        "default": "system",
-        "options": "light,dark,system"
-      },
-      {
-        "key": "language",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认语言",
-          "en-US": "Default Language"
-        },
-        "help": {
-          "zh-CN": "选择 auto 时使用访客浏览器语言。",
-          "en-US": "Use auto to follow the visitor browser language."
-        },
-        "default": "auto",
-        "options": "auto,en,zh-CN,zh-TW"
-      },
-      {
-        "key": "backgroundImageUrl",
-        "type": "string",
-        "name": {
-          "zh-CN": "背景图片链接",
-          "en-US": "Background Image URL"
-        },
-        "default": ""
-      },
-      {
-        "key": "backgroundBlurEnabled",
-        "type": "switch",
-        "name": {
-          "zh-CN": "启用背景模糊",
-          "en-US": "Enable Background Blur"
-        },
-        "default": false
-      },
-      {
-        "key": "backgroundBlurType",
-        "type": "select",
-        "name": {
-          "zh-CN": "背景模糊类型",
-          "en-US": "Background Blur Type"
-        },
-        "default": "soft",
-        "options": "soft,glass"
-      },
-      {
-        "key": "backgroundBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "背景模糊强度",
-          "en-US": "Background Blur Intensity"
-        },
-        "default": 35
-      },
-      {
-        "type": "title",
-        "name": "Status Cards"
-      },
-      {
-        "key": "statusCardsVisibility.currentTime",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示当前时间",
-          "en-US": "Show Current Time"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.currentOnline",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示当前在线",
-          "en-US": "Show Current Online"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.regionOverview",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示点亮地区",
-          "en-US": "Show Region Overview"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.trafficOverview",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示流量概览",
-          "en-US": "Show Traffic Overview"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.networkSpeed",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示网络速率",
-          "en-US": "Show Network Speed"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.mapView",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示地图",
-          "en-US": "Show Map View"
-        },
-        "default": true
-      }
-    ],
-    "data": [
-      {
-        "type": "title",
-        "name": "Theme Settings"
-      },
-      {
-        "key": "colorTheme",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认颜色主题",
-          "en-US": "Default Color Theme"
-        },
-        "help": {
-          "zh-CN": "设置主题默认颜色方案，访客仍可在本地覆盖。",
-          "en-US": "Set the default color scheme. Visitors can still override it locally."
-        },
-        "default": "default",
-        "options": "default,ocean,sunset,forest,midnight,rose"
-      },
-      {
-        "key": "cardLayout",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认卡片布局",
-          "en-US": "Default Card Layout"
-        },
-        "default": "classic",
-        "options": "classic,modern,minimal,detailed"
-      },
-      {
-        "key": "cardDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认卡片设计",
-          "en-US": "Default Card Design"
-        },
-        "default": "default",
-        "options": "default,quality-bars"
-      },
-      {
-        "key": "cardBlurEnabled",
-        "type": "switch",
-        "name": {
-          "zh-CN": "启用卡片背景模糊",
-          "en-US": "Enable Card Background Blur"
-        },
-        "default": false
-      },
-      {
-        "key": "cardBlurType",
-        "type": "select",
-        "name": {
-          "zh-CN": "卡片背景模糊类型",
-          "en-US": "Card Background Blur Type"
-        },
-        "default": "glass",
-        "options": "soft,glass"
-      },
-      {
-        "key": "cardBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "卡片背景透明强度",
-          "en-US": "Card Background Transparent Intensity"
-        },
-        "default": 35
-      },
-      {
-        "key": "cardExtraBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "卡片背景额外模糊强度",
-          "en-US": "Card Background Extra Blur Intensity"
-        },
-        "default": 35
-      },
-      {
-        "key": "statusDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认状态设计",
-          "en-US": "Default Status Design"
-        },
-        "default": "default",
-        "options": "default,speed"
-      },
-      {
-        "key": "graphDesign",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认图表设计",
-          "en-US": "Default Graph Design"
-        },
-        "default": "circle",
-        "options": "circle,progress,bar,minimal"
-      },
-      {
-        "key": "nodeViewMode",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认节点视图",
-          "en-US": "Default Node View"
-        },
-        "default": "grid",
-        "options": "grid,table"
-      },
-      {
-        "key": "appearance",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认外观",
-          "en-US": "Default Appearance"
-        },
-        "default": "system",
-        "options": "light,dark,system"
-      },
-      {
-        "key": "language",
-        "type": "select",
-        "name": {
-          "zh-CN": "默认语言",
-          "en-US": "Default Language"
-        },
-        "help": {
-          "zh-CN": "选择 auto 时使用访客浏览器语言。",
-          "en-US": "Use auto to follow the visitor browser language."
-        },
-        "default": "auto",
-        "options": "auto,en,zh-CN,zh-TW"
-      },
-      {
-        "key": "backgroundImageUrl",
-        "type": "string",
-        "name": {
-          "zh-CN": "背景图片链接",
-          "en-US": "Background Image URL"
-        },
-        "default": ""
-      },
-      {
-        "key": "backgroundBlurEnabled",
-        "type": "switch",
-        "name": {
-          "zh-CN": "启用背景模糊",
-          "en-US": "Enable Background Blur"
-        },
-        "default": false
-      },
-      {
-        "key": "backgroundBlurType",
-        "type": "select",
-        "name": {
-          "zh-CN": "背景模糊类型",
-          "en-US": "Background Blur Type"
-        },
-        "default": "soft",
-        "options": "soft,glass"
-      },
-      {
-        "key": "backgroundBlurIntensity",
-        "type": "number",
-        "name": {
-          "zh-CN": "背景模糊强度",
-          "en-US": "Background Blur Intensity"
-        },
-        "default": 35
-      },
-      {
-        "type": "title",
-        "name": "Status Cards"
-      },
-      {
-        "key": "statusCardsVisibility.currentTime",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示当前时间",
-          "en-US": "Show Current Time"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.currentOnline",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示当前在线",
-          "en-US": "Show Current Online"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.regionOverview",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示点亮地区",
-          "en-US": "Show Region Overview"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.trafficOverview",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示流量概览",
-          "en-US": "Show Traffic Overview"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.networkSpeed",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示网络速率",
-          "en-US": "Show Network Speed"
-        },
-        "default": true
-      },
-      {
-        "key": "statusCardsVisibility.mapView",
-        "type": "switch",
-        "name": {
-          "zh-CN": "显示地图",
-          "en-US": "Show Map View"
-        },
-        "default": true
-      }
-    ]
-  }
+        "data": [
+            {
+                "type": "title",
+                "name": "Theme Settings"
+            },
+            {
+                "key": "colorTheme",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认颜色主题",
+                    "en-US": "Default Color Theme"
+                },
+                "help": {
+                    "zh-CN": "设置主题默认颜色方案，访客仍可在本地覆盖。",
+                    "en-US": "Set the default color scheme. Visitors can still override it locally."
+                },
+                "default": "default",
+                "options": "default,ocean,sunset,forest,midnight,rose"
+            },
+            {
+                "key": "cardLayout",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认卡片布局",
+                    "en-US": "Default Card Layout"
+                },
+                "default": "classic",
+                "options": "classic,modern,minimal,detailed"
+            },
+            {
+                "key": "cardDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认卡片设计",
+                    "en-US": "Default Card Design"
+                },
+                "default": "default",
+                "options": "default,quality-bars"
+            },
+            {
+                "key": "cardBlurEnabled",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "启用卡片背景模糊",
+                    "en-US": "Enable Card Background Blur"
+                },
+                "default": false
+            },
+            {
+                "key": "cardBlurType",
+                "type": "select",
+                "name": {
+                    "zh-CN": "卡片背景模糊类型",
+                    "en-US": "Card Background Blur Type"
+                },
+                "default": "glass",
+                "options": "soft,glass"
+            },
+            {
+                "key": "cardBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "卡片背景透明强度",
+                    "en-US": "Card Background Transparent Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "cardExtraBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "卡片背景额外模糊强度",
+                    "en-US": "Card Background Extra Blur Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "statusDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认状态设计",
+                    "en-US": "Default Status Design"
+                },
+                "default": "default",
+                "options": "default,speed"
+            },
+            {
+                "key": "graphDesign",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认图表设计",
+                    "en-US": "Default Graph Design"
+                },
+                "default": "circle",
+                "options": "circle,progress,bar,minimal"
+            },
+            {
+                "key": "nodeViewMode",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认节点视图",
+                    "en-US": "Default Node View"
+                },
+                "default": "grid",
+                "options": "grid,table"
+            },
+            {
+                "key": "appearance",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认外观",
+                    "en-US": "Default Appearance"
+                },
+                "default": "system",
+                "options": "light,dark,system"
+            },
+            {
+                "key": "language",
+                "type": "select",
+                "name": {
+                    "zh-CN": "默认语言",
+                    "en-US": "Default Language"
+                },
+                "help": {
+                    "zh-CN": "选择 auto 时使用访客浏览器语言。",
+                    "en-US": "Use auto to follow the visitor browser language."
+                },
+                "default": "auto",
+                "options": "auto,en,zh-CN,zh-TW"
+            },
+            {
+                "key": "backgroundImageUrl",
+                "type": "string",
+                "name": {
+                    "zh-CN": "背景图片链接",
+                    "en-US": "Background Image URL"
+                },
+                "default": ""
+            },
+            {
+                "key": "backgroundBlurEnabled",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "启用背景模糊",
+                    "en-US": "Enable Background Blur"
+                },
+                "default": false
+            },
+            {
+                "key": "backgroundBlurType",
+                "type": "select",
+                "name": {
+                    "zh-CN": "背景模糊类型",
+                    "en-US": "Background Blur Type"
+                },
+                "default": "soft",
+                "options": "soft,glass"
+            },
+            {
+                "key": "backgroundBlurIntensity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "背景模糊强度",
+                    "en-US": "Background Blur Intensity"
+                },
+                "default": 35
+            },
+            {
+                "key": "backgroundMaskOpacity",
+                "type": "number",
+                "name": {
+                    "zh-CN": "背景蒙版不透明度",
+                    "en-US": "Background Mask Opacity"
+                },
+                "help": {
+                    "zh-CN": "在背景图片上叠加白色（浅色模式）或黑色（深色模式）蒙版，数值越大文字越易读。0 为不叠加，100 为完全覆盖。",
+                    "en-US": "Overlays a white (light mode) or black (dark mode) mask on the background image. Higher values improve text readability. 0 = no mask, 100 = fully covered."
+                },
+                "default": 0
+            },
+            {
+                "type": "title",
+                "name": "Status Cards"
+            },
+            {
+                "key": "statusCardsVisibility.currentTime",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示当前时间",
+                    "en-US": "Show Current Time"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.currentOnline",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示当前在线",
+                    "en-US": "Show Current Online"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.regionOverview",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示点亮地区",
+                    "en-US": "Show Region Overview"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.trafficOverview",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示流量概览",
+                    "en-US": "Show Traffic Overview"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.networkSpeed",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示网络速率",
+                    "en-US": "Show Network Speed"
+                },
+                "default": true
+            },
+            {
+                "key": "statusCardsVisibility.mapView",
+                "type": "switch",
+                "name": {
+                    "zh-CN": "显示地图",
+                    "en-US": "Show Map View"
+                },
+                "default": true
+            }
+        ]
+    }
 }

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -40,6 +40,7 @@ const ThemeSwitcher = () => {
     setBackgroundBlurEnabled,
     setBackgroundBlurType,
     setBackgroundBlurIntensity,
+    setBackgroundMaskOpacity,
     setCardBlurEnabled,
     setCardBlurType,
     setCardTransparentIntensity,
@@ -541,6 +542,32 @@ const ThemeSwitcher = () => {
                       onChange={(event) => setBackgroundBlurIntensity(Number(event.target.value))}
                       className="h-2 w-full cursor-pointer accent-primary"
                     />
+                  </div>
+                </div>
+              )}
+              {themeConfig.backgroundImageUrl && (
+                <div className="space-y-3">
+                  <div className="space-y-2">
+                    <div className="flex justify-between items-center">
+                      <span className="text-sm text-muted-foreground">
+                        {t('themeCustomizer.backgroundMaskOpacity', { defaultValue: 'Mask Opacity' })}
+                      </span>
+                      <span className="text-sm font-medium tabular-nums">
+                        {themeConfig.backgroundMaskOpacity}%
+                      </span>
+                    </div>
+                    <input
+                      type="range"
+                      min={0}
+                      max={100}
+                      step={5}
+                      value={themeConfig.backgroundMaskOpacity}
+                      onChange={(event) => setBackgroundMaskOpacity(Number(event.target.value))}
+                      className="h-2 w-full cursor-pointer accent-primary"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      {t('themeCustomizer.backgroundMaskOpacityHint', { defaultValue: 'Overlays white (light) or black (dark) on the background image to improve text readability.' })}
+                    </p>
                   </div>
                 </div>
               )}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -34,6 +34,7 @@ export interface ThemeConfig {
   backgroundBlurEnabled: boolean;
   backgroundBlurType: BackgroundBlurType;
   backgroundBlurIntensity: number;
+  backgroundMaskOpacity: number;
   cardBlurEnabled: boolean;
   cardBlurType: CardBlurType;
   // Persisted key kept for compatibility; this now drives card transparency.
@@ -74,6 +75,7 @@ interface ThemeContextType {
   setBackgroundBlurEnabled: (enabled: boolean) => void;
   setBackgroundBlurType: (type: BackgroundBlurType) => void;
   setBackgroundBlurIntensity: (intensity: number) => void;
+  setBackgroundMaskOpacity: (opacity: number) => void;
   setCardBlurEnabled: (enabled: boolean) => void;
   setCardBlurType: (type: CardBlurType) => void;
   setCardTransparentIntensity: (intensity: number) => void;
@@ -140,6 +142,7 @@ const DEFAULT_THEME_CONFIG: ThemeConfig = {
   backgroundBlurEnabled: false,
   backgroundBlurType: "soft",
   backgroundBlurIntensity: 35,
+  backgroundMaskOpacity: 0,
   cardBlurEnabled: false,
   cardBlurType: "glass",
   cardBlurIntensity: 35,
@@ -471,6 +474,7 @@ function normalizeThemeConfigOverrides(input: unknown): Partial<ThemeConfig> {
   const backgroundBlurEnabled = pickBoolean(input.backgroundBlurEnabled);
   const backgroundBlurType = pickBlurType(input.backgroundBlurType);
   const backgroundBlurIntensity = pickNumber(input.backgroundBlurIntensity);
+  const backgroundMaskOpacity = pickNumber(input.backgroundMaskOpacity);
   const cardBlurEnabled = pickBoolean(input.cardBlurEnabled);
   const cardBlurType = pickBlurType(input.cardBlurType);
   const cardBlurIntensity = pickNumber(input.cardBlurIntensity);
@@ -486,6 +490,9 @@ function normalizeThemeConfigOverrides(input: unknown): Partial<ThemeConfig> {
   if (backgroundBlurType) result.backgroundBlurType = backgroundBlurType;
   if (backgroundBlurIntensity !== undefined) {
     result.backgroundBlurIntensity = clampBackgroundBlurIntensity(backgroundBlurIntensity);
+  }
+  if (backgroundMaskOpacity !== undefined) {
+    result.backgroundMaskOpacity = clampBackgroundBlurIntensity(backgroundMaskOpacity);
   }
   if (cardBlurEnabled !== undefined) result.cardBlurEnabled = cardBlurEnabled;
   if (cardBlurType) result.cardBlurType = cardBlurType;
@@ -636,6 +643,7 @@ function mergeManagedSettings(
       "backgroundBlurEnabled",
       "backgroundBlurType",
       "backgroundBlurIntensity",
+      "backgroundMaskOpacity",
       "cardBlurEnabled",
       "cardBlurType",
       "cardBlurIntensity",
@@ -1037,6 +1045,7 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       document.body.style.removeProperty("--komari-custom-background-inset");
       document.body.style.removeProperty("--komari-custom-background-bleed");
       document.body.style.removeProperty("--komari-custom-background-scale");
+      document.body.style.removeProperty("--komari-custom-background-mask-opacity");
       return;
     }
 
@@ -1053,6 +1062,10 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     );
     document.body.style.setProperty("--komari-custom-background-filter", filter);
     document.body.style.setProperty("--komari-custom-background-bleed", bleed);
+    document.body.style.setProperty(
+      "--komari-custom-background-mask-opacity",
+      cssAlpha(themeConfig.backgroundMaskOpacity / 100)
+    );
     document.body.style.removeProperty("--komari-custom-background-inset");
     document.body.style.removeProperty("--komari-custom-background-scale");
   }, [
@@ -1060,6 +1073,7 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     themeConfig.backgroundBlurIntensity,
     themeConfig.backgroundBlurType,
     themeConfig.backgroundImageUrl,
+    themeConfig.backgroundMaskOpacity,
   ]);
 
   useEffect(() => {
@@ -1135,6 +1149,11 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       setLocalThemePatch({ backgroundBlurIntensity: clampBackgroundBlurIntensity(intensity) }),
     [setLocalThemePatch]
   );
+  const setBackgroundMaskOpacity = useCallback(
+    (opacity: number) =>
+      setLocalThemePatch({ backgroundMaskOpacity: clampBackgroundBlurIntensity(opacity) }),
+    [setLocalThemePatch]
+  );
   const setCardBlurEnabled = useCallback(
     (enabled: boolean) => setLocalThemePatch({ cardBlurEnabled: enabled }),
     [setLocalThemePatch]
@@ -1178,6 +1197,7 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       setBackgroundBlurEnabled,
       setBackgroundBlurType,
       setBackgroundBlurIntensity,
+      setBackgroundMaskOpacity,
       setCardBlurEnabled,
       setCardBlurType,
       setCardTransparentIntensity,
@@ -1198,6 +1218,7 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
       setBackgroundBlurIntensity,
       setBackgroundBlurType,
       setBackgroundImageUrl,
+      setBackgroundMaskOpacity,
       setAppearanceValue,
       setCardBlurEnabled,
       setCardBlurIntensity,

--- a/src/global.css
+++ b/src/global.css
@@ -175,6 +175,20 @@ body[data-custom-background="true"]::before {
   will-change: filter;
 }
 
+body[data-custom-background="true"]::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-color: white;
+  opacity: var(--komari-custom-background-mask-opacity, 0);
+}
+
+.dark body[data-custom-background="true"]::after {
+  background-color: black;
+}
+
 body[data-card-blur="true"] :is(
   [data-slot="card"]:not(.bg-transparent),
   [data-card-blur-surface="true"],

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -743,7 +743,9 @@
         "label": "Minimal",
         "description": "Simple text"
       }
-    }
+    },
+    "backgroundMaskOpacity": "Mask Opacity",
+    "backgroundMaskOpacityHint": "Overlays white (light mode) or black (dark mode) on the background image to improve text readability."
   },
   "terminal": {
     "disconnect": "Disconnected",

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -898,7 +898,9 @@
         "label": "速度仪表"
       }
     },
-    "themeSettings": "主题设置"
+    "themeSettings": "主题设置",
+    "backgroundMaskOpacity": "蒙版不透明度",
+    "backgroundMaskOpacityHint": "在背景图片上叠加白色（浅色模式）或黑色（深色模式）蒙版，数值越高文字越清晰可读。"
   },
   "time": {
     "ago": "前",

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -823,6 +823,8 @@
     },
     "backgroundImage": "背景图片",
     "backgroundImagePlaceholder": "输入图片 URL",
+    "backgroundMaskOpacity": "蒙版不透明度",
+    "backgroundMaskOpacityHint": "在背景图片上叠加白色（浅色模式）或黑色（深色模式）蒙版，数值越高文字越清晰可读。",
     "cardBackground": "卡片背景",
     "cardBlur": "卡片模糊",
     "cardBlurIntensity": "透明强度",
@@ -898,9 +900,7 @@
         "label": "速度仪表"
       }
     },
-    "themeSettings": "主题设置",
-    "backgroundMaskOpacity": "蒙版不透明度",
-    "backgroundMaskOpacityHint": "在背景图片上叠加白色（浅色模式）或黑色（深色模式）蒙版，数值越高文字越清晰可读。"
+    "themeSettings": "主题设置"
   },
   "time": {
     "ago": "前",

--- a/src/i18n/locales/zh_TW.json
+++ b/src/i18n/locales/zh_TW.json
@@ -743,7 +743,9 @@
         "label": "極簡",
         "description": "簡單文本"
       }
-    }
+    },
+    "backgroundMaskOpacity": "蒙版不透明度",
+    "backgroundMaskOpacityHint": "在背景圖片上疊加白色（淺色模式）或黑色（深色模式）蒙版，數值越高文字越清晰易讀。"
   },
   "terminal": {
     "disconnect": "連接已斷開",


### PR DESCRIPTION
https://github.com/tonyliuzj/komari-next/issues/35

测试过了，效果真的很好，这个功能也是所有komari主题都没有，但我最希望加入的功能。

在用komari之前还用过哪吒探针，也测试了一堆主题，也是完全没有一个哪吒主题是有类似的功能的。

因为我的背景图片是动态的，无法控制每张图片可以适配主题文字的颜色，加这个功能以后，所有图片都能适配了。

加上蒙版以后，连卡片的不透明和模糊的数据都不需要加那么高了，文字一样清晰，同时也能看到背景的图片

<img width="513" height="589" alt="2aa6560ee45b541274d844e0252505ea" src="https://github.com/user-attachments/assets/02ead36a-96a6-4cb8-8d20-f5847fae863e" />

上面对应的数值是75，真的贼贼贼好看

以下示范例子，都是把背景蒙版不透明度设置成50的效果

<img width="379" height="119" alt="image" src="https://github.com/user-attachments/assets/0dd0a3fe-ed9f-46e1-9c39-2c35f4beac31" />

# 要是把数值继续改大，文字会更清晰，毕竟会逐渐趋向纯白或者纯黑背景的，我最终使用的数值是75

## 浅色模式：
如果没有这个功能的效果
<img width="901" height="178" alt="image" src="https://github.com/user-attachments/assets/950d3ac3-2263-4193-964b-a9f2c6c872e5" />

加了这个功能以后

<img width="881" height="174" alt="image" src="https://github.com/user-attachments/assets/c6454f50-c5a9-478f-92b4-2917bd9893de" />

---

另一张背景图，如果没有这个功能的效果：
#### **右下角的版本号**更难看清了。。。
<img width="768" height="492" alt="image" src="https://github.com/user-attachments/assets/fa4edc83-04d2-48ed-bfd0-7042ef899d67" />

加了这个功能以后

<img width="769" height="603" alt="image" src="https://github.com/user-attachments/assets/41746279-d614-413c-9f59-588f9c597d12" />

## 深色模式：
如果没有这个功能的效果
<img width="865" height="694" alt="image" src="https://github.com/user-attachments/assets/be8ae748-fbdc-4f55-9ea7-747607f528b5" />

加了这个功能以后

<img width="850" height="708" alt="image" src="https://github.com/user-attachments/assets/2d1c2e43-58ac-4ea4-b137-c4eb3a663aa4" />

---

另一张背景图，如果没有这个功能，深色模式的效果：
<img width="797" height="360" alt="image" src="https://github.com/user-attachments/assets/35e594e6-3737-4572-935b-2942540d3bc5" />

加了这个功能以后

<img width="775" height="353" alt="image" src="https://github.com/user-attachments/assets/91d2d456-ae09-4868-883d-07dad241ca63" />



### 完全不需要背景模糊了好么，个人感觉这个功能出来的效果，比背景模糊好一万倍。

