### PR TITLE
style(NodeMapView): adjust layout for map-only view

### DIFF
--- a/src/components/NodeMapView.css
+++ b/src/components/NodeMapView.css
@@ -353,13 +353,31 @@
     min-height: 420px;
   }
 
+  .node-map-view__layout--map-only .node-map-view__surface {
+    min-height: 0;
+    grid-template-rows: auto auto;
+    align-content: start;
+  }
+
   .node-map-view__svg {
     min-height: 0;
+  }
+
+  .node-map-view__layout--map-only :is(.node-map-view__svg, .node-map-view__legend) {
+    grid-area: auto;
+  }
+
+  .node-map-view__layout--map-only .node-map-view__svg {
+    height: auto;
   }
 
   .node-map-view__legend {
     justify-content: center;
     padding: 0 0.85rem 0.52rem;
+  }
+
+  .node-map-view__layout--map-only .node-map-view__legend {
+    align-self: auto;
   }
 
   .node-map-view__legend--inset {


### PR DESCRIPTION
修改移动端地图区域的样式

之前：
<img width="918" height="524" alt="image" src="https://github.com/user-attachments/assets/ed500a69-97d8-4268-ba14-5897d1c1f431" />
<img width="412" height="524" alt="image" src="https://github.com/user-attachments/assets/183a304f-5be4-496f-8666-e3ab724f6a66" />

改后：
<img width="920" height="653" alt="image" src="https://github.com/user-attachments/assets/82532dd0-497d-4fd1-947e-d9a85ca2d52d" />
<img width="372" height="346" alt="image" src="https://github.com/user-attachments/assets/5a861c2d-6570-4bd6-9362-b1ae04d91a4d" />
